### PR TITLE
feat : OAuth2 로그인 및 JWT 기반 인증 처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,20 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // JJWT 공개 API
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    // 내부 구현체
+    runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.6'
+    // JSON 직렬화/역직렬화 모듈 ─ Jackson 사용 예시
+    runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/babzip/backend/global/config/security/AuthenticationConfig.java
+++ b/src/main/java/com/babzip/backend/global/config/security/AuthenticationConfig.java
@@ -1,0 +1,17 @@
+package com.babzip.backend.global.config.security;
+
+import com.babzip.backend.global.jwt.TokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+
+@Configuration
+public class AuthenticationConfig {
+    @Bean
+    public AuthenticationManager authenticationManager(
+            TokenProvider tokenProvider
+    ) {
+        return new ProviderManager(tokenProvider);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/config/security/JwtConfig.java
+++ b/src/main/java/com/babzip/backend/global/config/security/JwtConfig.java
@@ -1,0 +1,22 @@
+package com.babzip.backend.global.config.security;
+
+import com.babzip.backend.global.jwt.JwtHandler;
+import com.babzip.backend.global.jwt.JwtProperties;
+import com.babzip.backend.global.token.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Bean
+    public JwtHandler jwtHandler(JwtProperties jwtProperties) {
+        return new JwtHandler(jwtProperties, refreshTokenRepository);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/babzip/backend/global/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.babzip.backend.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    // @Bean은 해당 메서드의 리턴되는 오브젝트를 IoC로 등록해줌
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/babzip/backend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/babzip/backend/global/config/security/SecurityConfig.java
@@ -1,19 +1,35 @@
 package com.babzip.backend.global.config.security;
 
+import com.babzip.backend.global.jwt.JwtAuthenticationFilter;
+import com.babzip.backend.global.jwt.TokenProvider;
+import com.babzip.backend.global.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import com.babzip.backend.global.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableMethodSecurity
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final AuthenticationManager authenticationManager;
+
     @Bean
     public SecurityFilterChain filterChainPermitAll(HttpSecurity http) throws Exception {
         return defaultSecurity(http)
@@ -28,6 +44,28 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .cors(cors -> cors.configurationSource(CorsConfig.corsConfigurationSource()));
+                .cors(cors -> cors.configurationSource(CorsConfig.corsConfigurationSource()))
+                .oauth2Login(oauth2 ->
+                        oauth2.userInfoEndpoint(c -> c.userService(customOAuth2UserService))
+                                .successHandler(oAuth2AuthenticationSuccessHandler))
+                .addFilterAfter(new JwtAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter.class)
+                ;
     }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl
+                .withDefaultRolePrefix()  // 기본 접두어 "ROLE_" 사용
+                .role("ADMIN")            // ROLE_ADMIN
+                .implies("USER")        // ROLE_USER
+                .build();
+    }
+
+    @Bean
+    public MethodSecurityExpressionHandler expressionHandler(RoleHierarchy roleHierarchy) {
+        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+        expressionHandler.setRoleHierarchy(roleHierarchy);
+        return expressionHandler;
+    }
+
 }

--- a/src/main/java/com/babzip/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/babzip/backend/global/exception/ExceptionType.java
@@ -18,9 +18,23 @@ public enum ExceptionType {
     // Common
     UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR,"C001","예상치 못한 에러 발생"),
     BINDING_ERROR(BAD_REQUEST,"C002","바인딩시 에러 발생"),
-    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재");
+    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재"),
+
+    // Security
+    ILLEGAL_REGISTRATION_ID(NOT_ACCEPTABLE, "S001", "잘못된 registration id 입니다"),
+    NEED_AUTHORIZED(UNAUTHORIZED, "S002", "인증이 필요합니다."),
+    ACCESS_DENIED(FORBIDDEN, "S003", "권한이 없습니다."),
+    JWT_EXPIRED(UNAUTHORIZED, "S004", "JWT 토큰이 만료되었습니다."),
+    JWT_INVALID(UNAUTHORIZED, "S005", "JWT 토큰이 올바르지 않습니다."),
+    JWT_NOT_EXIST(UNAUTHORIZED, "S006", "JWT 토큰이 존재하지 않습니다."),
+
+    // Token
+    REFRESH_TOKEN_NOT_EXIST(NOT_FOUND, "T001", "리프래시 토큰이 존재하지 않습니다"),
+    TOKEN_NOT_MATCHED(UNAUTHORIZED, "T002","일치하지 않는 토큰입니다"),
 
 
+    // User
+    USER_NOT_FOUND(NOT_FOUND, "U001","사용자가 존재하지 않습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/babzip/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/babzip/backend/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package com.babzip.backend.global.jwt;
+
+import com.babzip.backend.global.exception.BusinessException;
+import com.babzip.backend.global.exception.ExceptionType;
+import com.babzip.backend.global.jwt.exception.JwtAuthenticationException;
+import com.babzip.backend.global.jwt.exception.JwtNotExistException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.babzip.backend.global.response.ResponseUtil.createFailureResponse;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final AuthenticationManager authenticationManager;
+    private final RequestMatcher requestMatcher = new RequestHeaderRequestMatcher(HttpHeaders.AUTHORIZATION);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        // Authorization 헤더가 있을 때만 필터를 거쳐감
+        // 인증이 필요없는 작업은 이 필터를 거치지 않음
+        if (!requestMatcher.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String tokenValue = resolveToken(request).orElseThrow(JwtNotExistException::new);
+            JwtAuthenticationToken token = new JwtAuthenticationToken(tokenValue); // 인증되지 않은 토큰
+            Authentication authentication = this.authenticationManager.authenticate(token); // TokenProvider에게 위임
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (JwtAuthenticationException e) {
+            this.handleServiceException(response, e);
+        }
+    }
+
+    private Optional<String> resolveToken(HttpServletRequest request){
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if(bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)){
+            return Optional.of(bearerToken.substring(BEARER_PREFIX.length()));
+        }
+        return Optional.empty();
+    }
+
+    private void handleServiceException(HttpServletResponse response, JwtAuthenticationException e) throws IOException {
+        response.setStatus(e.getErrorCode().getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String errorResponse = objectMapper.writeValueAsString(createFailureResponse(e.getErrorCode()));
+        response.getWriter().write(errorResponse);
+        response.flushBuffer(); // 커밋
+        response.getWriter().close();
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/babzip/backend/global/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,50 @@
+package com.babzip.backend.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public record JwtAuthenticationToken(
+        String token
+) implements Authentication {
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getDetails() {
+        return token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/JwtHandler.java
+++ b/src/main/java/com/babzip/backend/global/jwt/JwtHandler.java
@@ -1,0 +1,221 @@
+package com.babzip.backend.global.jwt;
+
+import com.babzip.backend.global.token.entity.RefreshToken;
+import com.babzip.backend.global.token.entity.Token;
+import com.babzip.backend.global.token.repository.RefreshTokenRepository;
+import com.babzip.backend.user.domain.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class JwtHandler {
+
+    private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+    private final RefreshTokenRepository refreshTokenRepository;
+    public static final String USER_ID = "USER_ID";
+    public static final String USER_ROLE = "USER_ROLE";
+    private static final String KEY_ROLE = "role";
+    private static final long MILLI_SECOND = 1000L;
+
+    public JwtHandler(JwtProperties jwtProperties, RefreshTokenRepository refreshTokenRepository) {
+        this.jwtProperties = jwtProperties;
+        this.refreshTokenRepository = refreshTokenRepository;
+        secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    // TODO : 추후에 제거
+    // accessToken 발급
+    public String generateAccessToken(Authentication authentication) {
+        return generateToken(authentication, jwtProperties.getAccessTokenExpireIn() * MILLI_SECOND);
+    }
+
+    // TODO : 추후에 제거
+    // refreshToken 발급
+    public void generateRefreshToken(Authentication authentication, String accessToken) {
+        // 랜덤 UUID로 refreshToken 생성
+        String refreshToken = UUID.randomUUID().toString();
+
+        // Jwt에서 클레임을 추출
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload();
+
+        // 클레임의 userId 추출
+        Long userId = claims.get("USER_ID", Long.class);
+        RefreshToken refreshTokenEntity = RefreshToken.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .build();
+        refreshTokenRepository.save(refreshTokenEntity); // refreshToken 저장
+    }
+
+    public Token createTokens(JwtUserClaim jwtUserClaim) {
+        Map<String, Object> tokenClaims = this.createClaims(jwtUserClaim);
+        Date now = new Date(System.currentTimeMillis());
+        long accessTokenExpireIn = jwtProperties.getAccessTokenExpireIn();
+
+        String accessToken = Jwts.builder()
+                .claims(tokenClaims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + accessTokenExpireIn * MILLI_SECOND))
+                .signWith(secretKey)
+                .compact();
+
+        String refreshToken = UUID.randomUUID().toString();
+
+        RefreshToken refreshTokenEntity = new RefreshToken(jwtUserClaim.userId(), refreshToken);
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        return Token.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Map<String, Object> createClaims(JwtUserClaim jwtUserClaim) {
+        return Map.of(
+                USER_ID, jwtUserClaim.userId(),
+                USER_ROLE, jwtUserClaim.role()
+        );
+    }
+
+    // TODO 추후에 제거
+    private String generateToken(Authentication authentication, long expireTime) {
+        Date now = new Date();
+        Date expiredDate = new Date(now.getTime() + expireTime);
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
+
+        return Jwts.builder()
+                .claim(KEY_ROLE, authorities)
+                .issuedAt(now)
+                .expiration(expiredDate)
+                .signWith(secretKey, Jwts.SIG.HS512)
+                .compact();
+    }
+
+    // TODO 이 코드들을 JwtAuthenticationFilter 로 옮겨야됨
+//    public Authentication getAuthentication(String token) {
+//        Claims claims = parseClaims(token);
+//        List<SimpleGrantedAuthority> authorities = getAuthorities(claims);
+//
+//        // 2. security의 User 객체 생성
+//        User principal = new User(claims.getSubject(), "", authorities);
+//        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+//    }
+//
+//    private List<SimpleGrantedAuthority> getAuthorities(Claims claims) {
+//        return Collections.singletonList(new SimpleGrantedAuthority(
+//                claims.get(KEY_ROLE).toString()));
+//    }
+
+
+    // TODO : 중복되는 로직. 액세스 토큰 재발급 api 개발 후 제거하기
+    // accessToken 재발급
+    // 클레임을 받아와서 클레임의 userId로 refreshToken을 찾음
+//    @Deprecated
+//    public String reissueAccessToken(String accessToken) {
+//        if (StringUtils.hasText(accessToken)) {
+//
+//            // Jwt에서 클레임을 추출
+//            Claims claims = Jwts.parser()
+//                    .verifyWith(secretKey)
+//                    .build()
+//                    .parseSignedClaims(accessToken)
+//                    .getPayload();
+//
+//            // 클레임의 userId 추출
+//            Long userId = claims.get(USER_ID, Long.class);
+//            RefreshToken refreshTokenEntity = refreshTokenRepository.findByUserId(userId)
+//                    .orElseThrow(() -> new RuntimeException("refreshToken not found"));
+//            String refreshToken = refreshTokenEntity.getRefreshToken();
+//
+//            // 리프래시 토큰이 유효하면 액세스 토큰 재발급
+//            if (validateToken(refreshToken)) {
+//                String reissueAccessToken = generateAccessToken(getAuthentication(refreshToken));
+//                return reissueAccessToken;
+//            }
+//        }
+//        return null;
+//    }
+
+
+    // 재발급을 위해 token이 만료되었더라도 claim을 반환하는 메서드
+    public Optional<JwtUserClaim> getClaims(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Optional.of(this.convert(claims));
+        } catch (ExpiredJwtException e) {
+            Claims claims = e.getClaims();
+            return Optional.of(this.convert(claims));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public JwtUserClaim convert(Claims claims) {
+        return new JwtUserClaim(
+                claims.get(USER_ID, Long.class),
+                UserRole.valueOf(claims.get(USER_ROLE, String.class))
+        );
+    }
+
+    // TODO : JwtAuthenticationFilter 개발 후 제거
+//    public boolean validateToken(String token) {
+//        if (!StringUtils.hasText(token)) {
+//            return false;
+//        }
+//
+//        Claims claims = parseClaims(token);
+//        return claims.getExpiration().after(new Date());
+//    }
+
+    // TODO : JwtAuthenticationFilter 개발 후 제거
+//    private Claims parseClaims(String token) {
+//        try {
+//            return Jwts.parser().verifyWith(secretKey).build()
+//                    .parseSignedClaims(token).getPayload();
+//        } catch (ExpiredJwtException e) {
+//            return e.getClaims();
+//        } catch (MalformedJwtException e) {
+//            throw e;
+////            throw new TokenException(INVALID_TOKEN);
+//        } catch (SecurityException e) {
+////            throw new TokenException(INVALID_JWT_SIGNATURE);
+//            throw e;
+//        }
+//    }
+
+    // 필터에서 토큰의 상태를 검증하기 위한 메서드 exception은 사용하는 곳에서 처리
+    public JwtUserClaim parseToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return this.convert(claims);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/JwtProperties.java
+++ b/src/main/java/com/babzip/backend/global/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.babzip.backend.global.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secretKey;
+    private int accessTokenExpireIn;
+    private int refreshTokenExpireIn;
+}

--- a/src/main/java/com/babzip/backend/global/jwt/JwtUserClaim.java
+++ b/src/main/java/com/babzip/backend/global/jwt/JwtUserClaim.java
@@ -1,0 +1,16 @@
+package com.babzip.backend.global.jwt;
+
+import com.babzip.backend.user.domain.User;
+import com.babzip.backend.user.domain.UserRole;
+
+public record  JwtUserClaim(
+        Long userId,
+        UserRole role
+) {
+    public static JwtUserClaim create(User user) {
+        return new JwtUserClaim(user.getId(), user.getRole());
+    }
+    public static JwtUserClaim create(Long userId, UserRole role) {
+        return new JwtUserClaim(userId, role);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/TokenProvider.java
+++ b/src/main/java/com/babzip/backend/global/jwt/TokenProvider.java
@@ -1,0 +1,59 @@
+package com.babzip.backend.global.jwt;
+
+import com.babzip.backend.global.jwt.exception.JwtAccessDeniedException;
+import com.babzip.backend.global.jwt.exception.JwtAuthentication;
+import com.babzip.backend.global.jwt.exception.JwtTokenExpiredException;
+import com.babzip.backend.global.jwt.exception.JwtTokenInvalidException;
+import com.babzip.backend.user.domain.UserRole;
+import com.babzip.backend.user.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+public class TokenProvider implements AuthenticationProvider {
+
+    private final JwtHandler jwtHandler;
+    private final UserService userService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+        String tokenValue = jwtAuthenticationToken.token();
+        if (tokenValue == null) {
+            System.out.println("null이에요");
+            return null;
+        }
+        System.out.println("널이 아니에여ㅛ");
+        try {
+            JwtUserClaim claims = jwtHandler.parseToken(tokenValue);
+            this.validateAdminRole(claims);
+            return new JwtAuthentication(claims);
+        } catch (ExpiredJwtException e) {
+            throw new JwtTokenExpiredException(e);
+        } catch (JwtAccessDeniedException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new JwtTokenInvalidException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private void validateAdminRole(JwtUserClaim claims) {
+        Long userId = claims.userId();
+        if (UserRole.ADMIN.equals(claims.role()) && !userService.isAdmin(userId)) {
+            throw new JwtAccessDeniedException();
+        }
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtAccessDeniedException.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtAccessDeniedException.java
@@ -1,0 +1,9 @@
+package com.babzip.backend.global.jwt.exception;
+
+import com.babzip.backend.global.exception.ExceptionType;
+
+public class JwtAccessDeniedException extends JwtAuthenticationException {
+    public JwtAccessDeniedException() {
+        super(ExceptionType.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtAuthentication.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtAuthentication.java
@@ -1,0 +1,61 @@
+package com.babzip.backend.global.jwt.exception;
+
+import com.babzip.backend.global.jwt.JwtUserClaim;
+import com.babzip.backend.user.domain.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public record JwtAuthentication(
+        Long userId,
+        UserRole role
+) implements Authentication {
+
+    public JwtAuthentication(JwtUserClaim claims) {
+        this(
+                claims.userId(),
+                claims.role()
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.role().name()));
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtAuthenticationException.java
@@ -1,0 +1,20 @@
+package com.babzip.backend.global.jwt.exception;
+
+import com.babzip.backend.global.exception.ExceptionType;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+    private ExceptionType errorCode;
+
+    public JwtAuthenticationException(ExceptionType errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtAuthenticationException(Throwable cause, ExceptionType errorCode) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtNotExistException.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtNotExistException.java
@@ -1,0 +1,9 @@
+package com.babzip.backend.global.jwt.exception;
+
+import com.babzip.backend.global.exception.ExceptionType;
+
+public class JwtNotExistException extends JwtAuthenticationException {
+    public JwtNotExistException() {
+        super(ExceptionType.JWT_NOT_EXIST);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtTokenExpiredException.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtTokenExpiredException.java
@@ -1,0 +1,14 @@
+package com.babzip.backend.global.jwt.exception;
+
+
+import com.babzip.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class JwtTokenExpiredException extends JwtAuthenticationException {
+
+    public JwtTokenExpiredException(Throwable cause) {
+        super(cause, ExceptionType.JWT_EXPIRED);
+    }
+
+}

--- a/src/main/java/com/babzip/backend/global/jwt/exception/JwtTokenInvalidException.java
+++ b/src/main/java/com/babzip/backend/global/jwt/exception/JwtTokenInvalidException.java
@@ -1,0 +1,14 @@
+package com.babzip.backend.global.jwt.exception;
+
+
+import com.babzip.backend.global.exception.ExceptionType;
+
+public class JwtTokenInvalidException extends JwtAuthenticationException {
+    public JwtTokenInvalidException() {
+        super(ExceptionType.JWT_INVALID);
+    }
+
+    public JwtTokenInvalidException(Throwable cause) {
+        super(cause, ExceptionType.JWT_INVALID);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/babzip/backend/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,21 @@
+package com.babzip.backend.global.oauth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        System.out.println("❌ OAuth2 로그인 실패: " + exception.getMessage());
+        exception.printStackTrace();  // 전체 스택 로그 출력
+
+        // 기본 리다이렉트
+        response.sendRedirect("/login?error");
+    }
+}

--- a/src/main/java/com/babzip/backend/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/babzip/backend/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.babzip.backend.global.oauth.handler;
+
+import com.babzip.backend.global.jwt.JwtHandler;
+import com.babzip.backend.global.jwt.JwtUserClaim;
+import com.babzip.backend.global.jwt.TokenProvider;
+import com.babzip.backend.global.oauth.service.OAuth2UserPrincipal;
+import com.babzip.backend.global.oauth.user.OAuth2Provider;
+import com.babzip.backend.global.token.entity.Token;
+import com.babzip.backend.user.domain.User;
+import com.babzip.backend.user.domain.UserRole;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtHandler jwtHandler;
+    private static final String URI = "/auth/success";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
+        Long userId = principal.getUser().getId();
+        UserRole role = principal.getUser().getRole();
+
+        JwtUserClaim jwtUserClaim = new JwtUserClaim(userId,role);
+        Token token = jwtHandler.createTokens(jwtUserClaim);
+
+        // 토큰 전달을 위한 redirect
+        String redirectUrl = UriComponentsBuilder.fromUriString(URI)
+                .queryParam("accessToken", token.getAccessToken())
+                .queryParam("refreshToken", token.getRefreshToken())
+                .build().toUriString();
+        System.out.println(redirectUrl);
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/babzip/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/babzip/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,91 @@
+package com.babzip.backend.global.oauth.service;
+
+import com.babzip.backend.global.oauth.user.OAuth2Provider;
+import com.babzip.backend.global.oauth.user.OAuth2UserInfo;
+import com.babzip.backend.user.domain.User;
+import com.babzip.backend.user.domain.UserRole;
+import com.babzip.backend.user.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 유저 정보(attributes) 가져오기
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+        // 2. registrationId 가져오기 (third-party id)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. userNameAttributeName 가져오기
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        String providerId = oAuth2UserAttributes.get(userNameAttributeName).toString();
+
+        // 4. 유저 정보 dto 생성
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, oAuth2UserAttributes);
+
+        // 5. 회원가입 및 로그인
+        User user = getOrSave(oAuth2UserInfo, registrationId, providerId);
+
+        log.info("Access Token: {}", userRequest.getAccessToken().getTokenValue());
+
+        // 추가적인 토큰 정보 로깅
+        log.info("Token Type: {}", userRequest.getAccessToken().getTokenType());
+        log.info("Scopes: {}", userRequest.getAccessToken().getScopes());
+        log.info("Expires At: {}", userRequest.getAccessToken().getExpiresAt());
+
+        // 클라이언트 등록 정보 로깅
+        log.info("Registration ID: {}", userRequest.getClientRegistration().getRegistrationId());
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // OAuth2User 정보 로깅
+        log.info("OAuth2User Attributes: {}", oAuth2User.getAttributes());
+        // 6. OAuth2User로 반환
+        return new OAuth2UserPrincipal(user, oAuth2UserAttributes, userNameAttributeName);
+
+
+    }
+
+    private User getOrSave(OAuth2UserInfo oAuth2UserInfo, String registrationId, String providerId) {
+
+        OAuth2Provider provider;
+        if(registrationId.equals("google")) {
+            provider = OAuth2Provider.GOOGLE;
+        }
+        else if(registrationId.equals("kakao")) {
+            provider = OAuth2Provider.KAKAO;
+        } else {
+            provider = null;
+        }
+
+        User user = memberRepository.findByEmail(oAuth2UserInfo.email())
+                .orElseGet(() ->
+                        User.builder()
+                                .email(oAuth2UserInfo.email())
+                                .role(UserRole.USER)
+                                .provider(provider)
+                                .providerId(providerId)
+                                .build()
+                );
+        return memberRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/babzip/backend/global/oauth/service/OAuth2UserPrincipal.java
+++ b/src/main/java/com/babzip/backend/global/oauth/service/OAuth2UserPrincipal.java
@@ -1,0 +1,49 @@
+package com.babzip.backend.global.oauth.service;
+
+import com.babzip.backend.global.oauth.user.OAuth2UserInfo;
+import com.babzip.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuth2UserPrincipal implements  OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+    private final String attributeKey;
+
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new SimpleGrantedAuthority(user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+}

--- a/src/main/java/com/babzip/backend/global/oauth/user/OAuth2Provider.java
+++ b/src/main/java/com/babzip/backend/global/oauth/user/OAuth2Provider.java
@@ -1,0 +1,14 @@
+package com.babzip.backend.global.oauth.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2Provider {
+    GOOGLE("google"),
+    NAVER("naver"),
+    KAKAO("kakao");
+
+    private final String registrationId;
+}

--- a/src/main/java/com/babzip/backend/global/oauth/user/OAuth2UserInfo.java
+++ b/src/main/java/com/babzip/backend/global/oauth/user/OAuth2UserInfo.java
@@ -1,0 +1,56 @@
+package com.babzip.backend.global.oauth.user;
+
+import com.babzip.backend.global.exception.BusinessException;
+import com.babzip.backend.user.domain.User;
+import jakarta.security.auth.message.AuthException;
+import lombok.Builder;
+import java.util.Map;
+import com.babzip.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+import static com.babzip.backend.user.domain.UserRole.USER;
+
+@Builder
+public record OAuth2UserInfo(
+        String name,
+        String email,
+        String profile
+) {
+
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) { // registration id별로 userInfo 생성
+            case "google" -> ofGoogle(attributes);
+            case "kakao" -> ofKakao(attributes);
+            default -> throw new BusinessException(ExceptionType.ILLEGAL_REGISTRATION_ID);
+        };
+    }
+
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        return OAuth2UserInfo.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .profile((String) attributes.get("picture"))
+                .build();
+    }
+
+    // TODO : 구글 도입 후에 카카오 도입
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        return OAuth2UserInfo.builder()
+                .name((String) profile.get("nickname"))
+                .email((String) account.get("email"))
+                .profile((String) profile.get("profile_image_url"))
+                .build();
+    }
+
+
+//    public User toEntity() {
+//        return User.builder()
+//                .email(email)
+//                .role(USER)
+//                .provider(provider)
+//                .build()
+//    }
+}

--- a/src/main/java/com/babzip/backend/global/token/controller/TokenController.java
+++ b/src/main/java/com/babzip/backend/global/token/controller/TokenController.java
@@ -1,0 +1,31 @@
+package com.babzip.backend.global.token.controller;
+
+import com.babzip.backend.global.response.ResponseBody;
+import com.babzip.backend.global.token.dto.request.TokenRequest;
+import com.babzip.backend.global.token.dto.response.TokenResponse;
+import com.babzip.backend.global.token.entity.Token;
+import com.babzip.backend.global.token.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.babzip.backend.global.response.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequestMapping("/auth/token")
+@RequiredArgsConstructor
+public class TokenController {
+    private final TokenService tokenService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ResponseBody<TokenResponse>> refresh(@RequestBody  TokenRequest tokenRequest) {
+        Token token = new Token(tokenRequest.accessToken(), tokenRequest.refreshToken());
+        TokenResponse response = tokenService.refresh(token);
+        return ResponseEntity.ok(createSuccessResponse(response));
+    }
+}

--- a/src/main/java/com/babzip/backend/global/token/dto/request/TokenRequest.java
+++ b/src/main/java/com/babzip/backend/global/token/dto/request/TokenRequest.java
@@ -1,0 +1,8 @@
+package com.babzip.backend.global.token.dto.request;
+
+public record TokenRequest (
+    String accessToken,
+    String refreshToken
+){
+
+}

--- a/src/main/java/com/babzip/backend/global/token/dto/response/TokenResponse.java
+++ b/src/main/java/com/babzip/backend/global/token/dto/response/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.babzip.backend.global.token.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/babzip/backend/global/token/entity/RefreshToken.java
+++ b/src/main/java/com/babzip/backend/global/token/entity/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.babzip.backend.global.token.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String refreshToken;
+
+    @Builder
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/babzip/backend/global/token/entity/Token.java
+++ b/src/main/java/com/babzip/backend/global/token/entity/Token.java
@@ -1,0 +1,16 @@
+package com.babzip.backend.global.token.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Token {
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public Token(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/babzip/backend/global/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/babzip/backend/global/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.babzip.backend.global.token.repository;
+
+import com.babzip.backend.global.token.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByuserId(Long userId);
+}

--- a/src/main/java/com/babzip/backend/global/token/service/TokenService.java
+++ b/src/main/java/com/babzip/backend/global/token/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.babzip.backend.global.token.service;
+
+import com.babzip.backend.global.exception.BusinessException;
+import com.babzip.backend.global.exception.ExceptionType;
+import com.babzip.backend.global.jwt.JwtHandler;
+import com.babzip.backend.global.jwt.JwtUserClaim;
+import com.babzip.backend.global.token.dto.response.TokenResponse;
+import com.babzip.backend.global.token.entity.RefreshToken;
+import com.babzip.backend.global.token.entity.Token;
+import com.babzip.backend.global.token.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.service.spi.ServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtHandler jwtHandler;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public TokenResponse refresh(Token token) {
+        JwtUserClaim jwtUserClaim = jwtHandler.getClaims(token.getAccessToken())
+                .orElseThrow(() -> new BusinessException(ExceptionType.JWT_INVALID)); // invalid token
+
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByUserId(jwtUserClaim.userId())
+                .orElseThrow(() -> new BusinessException(ExceptionType.REFRESH_TOKEN_NOT_EXIST)); // not exist token
+
+        if(!token.getRefreshToken().equals(savedRefreshToken.getRefreshToken())) // userId 비교
+            throw new BusinessException(ExceptionType.TOKEN_NOT_MATCHED);
+
+        refreshTokenRepository.deleteByuserId(savedRefreshToken.getUserId());
+
+        Token tokenResponse = jwtHandler.createTokens(jwtUserClaim);
+        return new TokenResponse(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+    }
+
+
+}

--- a/src/main/java/com/babzip/backend/user/controller/UserController.java
+++ b/src/main/java/com/babzip/backend/user/controller/UserController.java
@@ -1,0 +1,18 @@
+package com.babzip.backend.user.controller;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+    @GetMapping("/hello")
+    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    public String hello(){
+        return "Hello World";
+    }
+
+}

--- a/src/main/java/com/babzip/backend/user/domain/User.java
+++ b/src/main/java/com/babzip/backend/user/domain/User.java
@@ -1,0 +1,41 @@
+package com.babzip.backend.user.domain;
+
+import com.babzip.backend.global.base.BaseEntity;
+import com.babzip.backend.global.oauth.user.OAuth2Provider;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+//    @Column(unique = true)
+//    private String nickname;
+
+    @Enumerated(value = EnumType.STRING)
+    @Getter
+    private UserRole role;
+
+    @Enumerated(value = EnumType.STRING)
+    private OAuth2Provider provider;
+
+    private String providerId;
+
+    @Builder
+    public User(String email, UserRole role, OAuth2Provider provider, String providerId) {
+        this.email = email;
+        this.role = role;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+}

--- a/src/main/java/com/babzip/backend/user/domain/UserRole.java
+++ b/src/main/java/com/babzip/backend/user/domain/UserRole.java
@@ -1,0 +1,16 @@
+package com.babzip.backend.user.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum UserRole {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+}

--- a/src/main/java/com/babzip/backend/user/repository/MemberRepository.java
+++ b/src/main/java/com/babzip/backend/user/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.babzip.backend.user.repository;
+
+import com.babzip.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/babzip/backend/user/service/UserService.java
+++ b/src/main/java/com/babzip/backend/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.babzip.backend.user.service;
+
+import com.babzip.backend.global.exception.BusinessException;
+import com.babzip.backend.global.exception.ExceptionType;
+import com.babzip.backend.user.domain.User;
+import com.babzip.backend.user.domain.UserRole;
+import com.babzip.backend.user.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Member;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final MemberRepository memberRepository;
+
+    public boolean isAdmin(Long userId) {
+        User user = memberRepository.findById(userId)
+                .orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        System.out.println("유저의 권한: " + user.getRole());
+        System.out.println("어드민 권한이 일치한지 확인한다 : " + UserRole.ADMIN);
+        return user.getRole().equals(UserRole.ADMIN);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,12 +2,17 @@ spring:
   config:
     activate:
       on-profile: dev
+    import:
+      - application-security.yml
 
   datasource:
     url: jdbc:mysql://localhost:3307/babzipdb
     username: babzip
     password: "babzippass"
     driver-class-name: com.mysql.cj.jdbc.Driver
+
+  mvc:
+    log-request-details: true
 
   jpa:
     hibernate:
@@ -19,3 +24,4 @@ spring:
         format_sql: false
         highlight_sql: true
         default_batch_fetch_size: 100
+

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,23 @@
+jwt:
+  secret-key: Zr2PMyKH4UheWy6zscq6Wc/nSLl6L/AJ6b5QvLzWXJg5wzQiGdJncTTOBCxvW8Rkl1T0N+1bqF52Mw2eZvwA0i5zyq+VVbIjPyz+b7DW0Xd2wTnXifwxM12LU2oyXpyLz
+  access-token-expire-in: 1800
+  refresh-token-expire-in: 1209600
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+              client-id: 540803440273-6dtj5tfo86g1vj3vll8jvp6q450nvttr.apps.googleusercontent.com
+              client-secret: ${GOOGLE_SECRET}
+              scope: # google API의 범위 값
+                - profile
+                - email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+


### PR DESCRIPTION
## What is this PR?🔍
- OAuth2.0 로그인 및 JWT 기반 인증 처리 코드를 작성했습니다.
- 현재는 구글 로그인만 가능합니다.
- 현재 userId를 가져오는 로직이 구현되지 않았기 때문에, 해당 PR 머지전까지는 userId가 필요한 API의 경우 메서드 인자에 Long userId로 입력받아서 개발해주세요!
- 현재 `UserController`에 구현된 API `hello()`는 인증, 인가 작동을 확인하는 테스트 API입니다. 인증된 사용자가 USER 이상의 권한을 가지면 API를 사용할 수 있도록 구현했습니다. 추후에 이러한 방식으로 코드를 작성하니 참고하시면 됩니다.
- 현재는 로그인만 구현된 상태입니다. 로그아웃도 빠른 시일 내에 개발하여 추후 PR에 올리겠습니다.
- OAuth 로그인 후 리다이렉션되는 URL을 프론트와 상의해서 결정해야할 것 같습니다

### 전체적인 흐름은 다음과 같습니다.
1. 사용자는 OAuth를 통해 로그인합니다.
2. 서버는 accessToken과 refreshToken을 생성하여 OAuth 로그인을 성공한 사용자에게 반환합니다.
3. 이후 사용자는 인증을 위해 accessToken을 서버에 제공하고 서버는 accessToken이 유효한지 확인 후 요청받은 기능을 제공합니다.
4. accessToken이 만료된 사용자는 accessToken 재발급을 요청하여 accessToken과 refreshToken을 재발급받습니다.

## Changes💻
-  User 도메인에 인증,인가 테스트를 위한 API를 추가했습니다
- Token 도메인에 accessToken 재발급을 위한 API를 추가했습니다
- 

## ScreenShot📷
