### PR TITLE
Feat: 음식점 검색 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,26 +24,40 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // JJWT 공개 API
+
+    // OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // Mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    // 내부 구현체
     runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.12.6'
-    // JSON 직렬화/역직렬화 모듈 ─ Jackson 사용 예시
     runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     // Aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // Webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 }
 

--- a/src/main/java/com/babzip/backend/BabzipApplication.java
+++ b/src/main/java/com/babzip/backend/BabzipApplication.java
@@ -1,11 +1,14 @@
 package com.babzip.backend;
 
+import com.babzip.backend.global.oauth.user.KakaoProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableConfigurationProperties(KakaoProperties.class)
 public class BabzipApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/babzip/backend/global/config/web/WebClientConfig.java
+++ b/src/main/java/com/babzip/backend/global/config/web/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.babzip.backend.global.config.web;
+
+import com.babzip.backend.global.oauth.user.KakaoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient kakaoWebClient(KakaoProperties kakaoProperties) {
+        return WebClient.builder()
+                .baseUrl("https://dapi.kakao.com/v2/local")
+                .defaultHeader(HttpHeaders.AUTHORIZATION,
+                        "KakaoAK " + kakaoProperties.getClientId())
+                .build();
+    }
+}

--- a/src/main/java/com/babzip/backend/global/oauth/user/KakaoProperties.java
+++ b/src/main/java/com/babzip/backend/global/oauth/user/KakaoProperties.java
@@ -1,0 +1,17 @@
+package com.babzip.backend.global.oauth.user;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration.kakao")
+public class KakaoProperties {
+
+    private String clientId;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+}

--- a/src/main/java/com/babzip/backend/search/controller/SearchController.java
+++ b/src/main/java/com/babzip/backend/search/controller/SearchController.java
@@ -1,0 +1,30 @@
+package com.babzip.backend.search.controller;
+
+import com.babzip.backend.global.response.ResponseBody;
+import com.babzip.backend.search.dto.request.SearchRequest;
+import com.babzip.backend.search.dto.response.SearchResponse;
+import com.babzip.backend.search.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.babzip.backend.global.response.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/search")
+    @PreAuthorize(" isAuthenticated()")
+    public ResponseEntity<ResponseBody<SearchResponse>> search(@RequestBody SearchRequest request){
+        SearchResponse response = searchService.search(request);
+        return ResponseEntity.ok(createSuccessResponse(response));
+    }
+}

--- a/src/main/java/com/babzip/backend/search/dto/request/SearchRequest.java
+++ b/src/main/java/com/babzip/backend/search/dto/request/SearchRequest.java
@@ -1,0 +1,9 @@
+package com.babzip.backend.search.dto.request;
+
+public record SearchRequest (
+    String query,
+    String x, // 경도
+    String y // 위도
+){
+
+}

--- a/src/main/java/com/babzip/backend/search/dto/request/SearchRequest.java
+++ b/src/main/java/com/babzip/backend/search/dto/request/SearchRequest.java
@@ -3,7 +3,8 @@ package com.babzip.backend.search.dto.request;
 public record SearchRequest (
     String query,
     String x, // 경도
-    String y // 위도
+    String y, // 위도
+    Long page
 ){
 
 }

--- a/src/main/java/com/babzip/backend/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/babzip/backend/search/dto/response/SearchResponse.java
@@ -1,0 +1,34 @@
+package com.babzip.backend.search.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true) // 역직렬화 시 JSON에 DTO에 없는 필드가 들어 있어도 무시하고 오류를 내지 않음
+public record SearchResponse(
+        Meta meta,
+        List<Document> documents
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Meta(
+            @JsonProperty("is_end") boolean isEnd
+    ) {}
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Document(
+            String placeName,
+            String distance,
+            String placeUrl,
+            String categoryName,
+            String addressName,
+            String roadAddressName,
+            String id,
+            String phone,
+            String x,
+            String y
+    ) {}
+}

--- a/src/main/java/com/babzip/backend/search/service/SearchService.java
+++ b/src/main/java/com/babzip/backend/search/service/SearchService.java
@@ -1,0 +1,45 @@
+package com.babzip.backend.search.service;
+
+import com.babzip.backend.global.oauth.user.KakaoProperties;
+import com.babzip.backend.search.dto.request.SearchRequest;
+import com.babzip.backend.search.dto.response.SearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SearchService {
+
+    // TODO : 카카오 API 호출 후 결과를 컨트롤러에 반환하기. 사용자 위치에서 가까운 순으로. 반경 10km. 그룹코드 FD6
+    private final KakaoProperties kakaoProperties;
+    private final WebClient webClient;
+
+    public SearchResponse search(SearchRequest request){
+
+        String query = request.query();
+        String x = request.x();
+        String y = request.y();
+        String groupCode = "FD6";
+        Long radius = 10000L;
+        String output = "json";
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/search/keyword.json")
+                        .queryParam("query", query)
+                        .queryParam("category_group_code", groupCode)
+                        .queryParam("x",x)
+                        .queryParam("y",y)
+                        .queryParam("radius",radius)
+                        .build())
+                .retrieve()
+                .bodyToMono(SearchResponse.class)
+                .block(Duration.ofSeconds(3));
+    }
+
+}

--- a/src/main/java/com/babzip/backend/search/service/SearchService.java
+++ b/src/main/java/com/babzip/backend/search/service/SearchService.java
@@ -23,9 +23,9 @@ public class SearchService {
         String query = request.query();
         String x = request.x();
         String y = request.y();
+        Long page = request.page();
         String groupCode = "FD6";
         Long radius = 10000L;
-        String output = "json";
 
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -35,6 +35,7 @@ public class SearchService {
                         .queryParam("x",x)
                         .queryParam("y",y)
                         .queryParam("radius",radius)
+                        .queryParam("page",page)
                         .build())
                 .retrieve()
                 .bodyToMono(SearchResponse.class)

--- a/src/main/java/com/babzip/backend/search/service/SearchService.java
+++ b/src/main/java/com/babzip/backend/search/service/SearchService.java
@@ -15,7 +15,6 @@ import java.time.Duration;
 @Slf4j
 public class SearchService {
 
-    // TODO : 카카오 API 호출 후 결과를 컨트롤러에 반환하기. 사용자 위치에서 가까운 순으로. 반경 10km. 그룹코드 FD6
     private final KakaoProperties kakaoProperties;
     private final WebClient webClient;
 


### PR DESCRIPTION
## What is this PR?🔍
- 음식점 검색 기능을 추가했습니다.

## Changes💻
- WebClient를 사용하여 카카오 검색 api `https://dapi.kakao.com/v2/local/search/keyword.${FORMAT} `에 GET 요청을 보내 응답을 받아옵니다.
- is-end는 현재 가져온 페이지가 마지막 페이지인지 알려줍니다. true면 마지막 페이지, false이면 마지막 페이지가 아닙니다.
- documents에 있는 리스트는 검색어와 관련있는 음식점들의 정보를 나열합니다.
<br class="Apple-interchange-newline">
-
-

## ScreenShot📷
<img width="519" height="583" alt="image" src="https://github.com/user-attachments/assets/2709c2d5-a87d-451c-9e96-caecf0a8d4dc" />
