### PR TITLE
feat: 방명록 CRUD 기능 

### DIFF
--- a/src/main/java/com/babzip/backend/global/aop/AssignUserId.java
+++ b/src/main/java/com/babzip/backend/global/aop/AssignUserId.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
 public @interface AssignUserId {
     boolean required() default true;
 }

--- a/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
@@ -1,0 +1,49 @@
+package com.babzip.backend.guestbook.controller;
+
+import com.babzip.backend.guestbook.dto.request.GuestbookRequestDto;
+import com.babzip.backend.guestbook.dto.response.GuestbookResponseDto;
+import com.babzip.backend.guestbook.service.GuestbookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/guestbooks")
+@RequiredArgsConstructor
+public class GuestbookController {
+    private final GuestbookService guestbookService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestParam Long userId,
+                                       @RequestBody GuestbookRequestDto dto) {
+        guestbookService.create(userId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/restaurant/{kakaoPlaceId}")
+    public ResponseEntity<List<GuestbookResponseDto>> getByKakaoPlaceId(@PathVariable String kakaoPlaceId) {
+        return ResponseEntity.ok(guestbookService.getByKakaoPlaceId(kakaoPlaceId));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<GuestbookResponseDto>> getMyGuestbooks(@RequestParam Long userId) {
+        return ResponseEntity.ok(guestbookService.getByUserId(userId));
+    }
+
+    @PutMapping("/{guestbookId}")
+    public ResponseEntity<Void> update(@PathVariable Long guestbookId,
+                                       @RequestParam Long userId,
+                                       @RequestBody GuestbookRequestDto dto) {
+        guestbookService.update(guestbookId, userId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{guestbookId}")
+    public ResponseEntity<Void> delete(@PathVariable Long guestbookId,
+                                       @RequestParam Long userId) {
+        guestbookService.delete(guestbookId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
@@ -38,15 +38,6 @@ public class GuestbookController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 
-    @PutMapping("/{guestbookId}")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<Void>> updateAll(@AssignUserId Long userId,
-                                                        @PathVariable Long guestbookId,
-                                                        @RequestBody GuestbookRequestDto requestDto) {
-        guestbookService.updateAll(userId, guestbookId, requestDto);
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
-    }
-
     @PatchMapping("/{guestbookId}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ResponseBody<Void>> updatePartial(@AssignUserId Long userId,

--- a/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/babzip/backend/guestbook/controller/GuestbookController.java
@@ -1,49 +1,66 @@
 package com.babzip.backend.guestbook.controller;
 
+import com.babzip.backend.global.aop.AssignUserId;
+import com.babzip.backend.global.response.ResponseBody;
+import com.babzip.backend.global.response.ResponseUtil;
 import com.babzip.backend.guestbook.dto.request.GuestbookRequestDto;
 import com.babzip.backend.guestbook.dto.response.GuestbookResponseDto;
 import com.babzip.backend.guestbook.service.GuestbookService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-@RestController
-@RequestMapping("/guestbooks")
 @RequiredArgsConstructor
+@RestController
+@RequestMapping("/guestbook")
 public class GuestbookController {
+
     private final GuestbookService guestbookService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@RequestParam Long userId,
-                                       @RequestBody GuestbookRequestDto dto) {
-        guestbookService.create(userId, dto);
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/restaurant/{kakaoPlaceId}")
-    public ResponseEntity<List<GuestbookResponseDto>> getByKakaoPlaceId(@PathVariable String kakaoPlaceId) {
-        return ResponseEntity.ok(guestbookService.getByKakaoPlaceId(kakaoPlaceId));
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> create(@AssignUserId Long userId,
+                                                     @RequestBody GuestbookRequestDto requestDto) {
+        guestbookService.create(userId, requestDto);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<GuestbookResponseDto>> getMyGuestbooks(@RequestParam Long userId) {
-        return ResponseEntity.ok(guestbookService.getByUserId(userId));
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Page<GuestbookResponseDto>>> getMyGuestbooks(
+            @AssignUserId Long userId,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<GuestbookResponseDto> response = guestbookService.getByUserId(userId, pageable);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(response));
     }
 
     @PutMapping("/{guestbookId}")
-    public ResponseEntity<Void> update(@PathVariable Long guestbookId,
-                                       @RequestParam Long userId,
-                                       @RequestBody GuestbookRequestDto dto) {
-        guestbookService.update(guestbookId, userId, dto);
-        return ResponseEntity.ok().build();
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> updateAll(@AssignUserId Long userId,
+                                                        @PathVariable Long guestbookId,
+                                                        @RequestBody GuestbookRequestDto requestDto) {
+        guestbookService.updateAll(userId, guestbookId, requestDto);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+
+    @PatchMapping("/{guestbookId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> updatePartial(@AssignUserId Long userId,
+                                                            @PathVariable Long guestbookId,
+                                                            @RequestBody GuestbookRequestDto requestDto) {
+        guestbookService.updatePartial(userId, guestbookId, requestDto);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 
     @DeleteMapping("/{guestbookId}")
-    public ResponseEntity<Void> delete(@PathVariable Long guestbookId,
-                                       @RequestParam Long userId) {
-        guestbookService.delete(guestbookId, userId);
-        return ResponseEntity.ok().build();
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<Void>> delete(@AssignUserId Long userId,
+                                                     @PathVariable Long guestbookId) {
+        guestbookService.delete(userId, guestbookId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 }

--- a/src/main/java/com/babzip/backend/guestbook/dto/request/GuestbookRequestDto.java
+++ b/src/main/java/com/babzip/backend/guestbook/dto/request/GuestbookRequestDto.java
@@ -1,0 +1,15 @@
+package com.babzip.backend.guestbook.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class GuestbookRequestDto {
+    private String kakaoPlaceId; // 카카오에서 받은 음식점 ID
+    private String content;
+    private Long rating;
+}
+

--- a/src/main/java/com/babzip/backend/guestbook/dto/request/GuestbookRequestDto.java
+++ b/src/main/java/com/babzip/backend/guestbook/dto/request/GuestbookRequestDto.java
@@ -3,13 +3,10 @@ package com.babzip.backend.guestbook.dto.request;
 import lombok.*;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 
 public class GuestbookRequestDto {
     private String kakaoPlaceId; // 카카오에서 받은 음식점 ID
     private String content;
-    private Long rating;
+    private Integer rating;
 }
 

--- a/src/main/java/com/babzip/backend/guestbook/dto/response/GuestbookResponseDto.java
+++ b/src/main/java/com/babzip/backend/guestbook/dto/response/GuestbookResponseDto.java
@@ -1,15 +1,19 @@
 package com.babzip.backend.guestbook.dto.response;
 
-import lombok.*;
+import com.babzip.backend.guestbook.entity.Guestbook;
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-
-public class GuestbookResponseDto {
-    private Long guestbookId;
-    private String kakaoPlaceId;
-    private String content;
-    private Long rating;
+public record GuestbookResponseDto(
+        Long id,
+        String kakaoPlaceId,
+        String content,
+        Integer rating
+) {
+    public static GuestbookResponseDto toDto(Guestbook guestbook) {
+        return new GuestbookResponseDto(
+                guestbook.getId(),
+                guestbook.getKakaoPlaceId(),
+                guestbook.getContent(),
+                guestbook.getRating()
+        );
+    }
 }

--- a/src/main/java/com/babzip/backend/guestbook/dto/response/GuestbookResponseDto.java
+++ b/src/main/java/com/babzip/backend/guestbook/dto/response/GuestbookResponseDto.java
@@ -1,0 +1,15 @@
+package com.babzip.backend.guestbook.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class GuestbookResponseDto {
+    private Long guestbookId;
+    private String kakaoPlaceId;
+    private String content;
+    private Long rating;
+}

--- a/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
@@ -1,32 +1,44 @@
 package com.babzip.backend.guestbook.entity;
 
-import com.babzip.backend.global.base.BaseEntity;
 import com.babzip.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@AllArgsConstructor
 
-public class Guestbook extends BaseEntity {
+
+public class Guestbook {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long guestbookId;
+    private Long id;
+
+    private String kakaoPlaceId;
+    private String content;
+    private Integer rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @Column(nullable = false)
-    private String kakaoPlaceId;
+    public Guestbook(User user, String kakaoPlaceId, String content, Integer rating) {
+        this.user = user;
+        this.kakaoPlaceId = kakaoPlaceId;
+        this.content = content;
+        this.rating = rating;
+    }
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;
+    public void updateAll(String kakaoPlaceId, String content, Integer rating) {
+        this.kakaoPlaceId = kakaoPlaceId;
+        this.content = content;
+        this.rating = rating;
+    }
 
-    @Column
-    private Long rating;
+    public void updatePartial(String content, Integer rating) {
+        if (content != null) this.content = content;
+        if (rating != null) this.rating = rating;
+    }
 }

--- a/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
@@ -31,13 +31,8 @@ public class Guestbook {
         this.rating = rating;
     }
 
-    public void updateAll(String kakaoPlaceId, String content, Integer rating) {
-        this.kakaoPlaceId = kakaoPlaceId;
-        this.content = content;
-        this.rating = rating;
-    }
-
-    public void updatePartial(String content, Integer rating) {
+    public void updatePartial(String kakaoPlaceId, String content, Integer rating) {
+        if (kakaoPlaceId != null) this.kakaoPlaceId = kakaoPlaceId;
         if (content != null) this.content = content;
         if (rating != null) this.rating = rating;
     }

--- a/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/babzip/backend/guestbook/entity/Guestbook.java
@@ -1,0 +1,32 @@
+package com.babzip.backend.guestbook.entity;
+
+import com.babzip.backend.global.base.BaseEntity;
+import com.babzip.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class Guestbook extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long guestbookId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String kakaoPlaceId;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column
+    private Long rating;
+}

--- a/src/main/java/com/babzip/backend/guestbook/repository/GuestbookRepository.java
+++ b/src/main/java/com/babzip/backend/guestbook/repository/GuestbookRepository.java
@@ -1,13 +1,13 @@
 package com.babzip.backend.guestbook.repository;
 
 import com.babzip.backend.guestbook.entity.Guestbook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
-    List<Guestbook> findByKakaoPlaceId(String kakaoPlaceId);
-    List<Guestbook> findByUserId(Long userId);
-    Optional<Guestbook> findByIdAndUserId(Long guestbookId, Long userId);
+    Page<Guestbook> findByUserId(Long userId, Pageable pageable);
+    Optional<Guestbook> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/babzip/backend/guestbook/repository/GuestbookRepository.java
+++ b/src/main/java/com/babzip/backend/guestbook/repository/GuestbookRepository.java
@@ -1,0 +1,13 @@
+package com.babzip.backend.guestbook.repository;
+
+import com.babzip.backend.guestbook.entity.Guestbook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GuestbookRepository extends JpaRepository<Guestbook, Long> {
+    List<Guestbook> findByKakaoPlaceId(String kakaoPlaceId);
+    List<Guestbook> findByUserId(Long userId);
+    Optional<Guestbook> findByIdAndUserId(Long guestbookId, Long userId);
+}

--- a/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
@@ -6,64 +6,58 @@ import com.babzip.backend.guestbook.entity.Guestbook;
 import com.babzip.backend.guestbook.repository.GuestbookRepository;
 import com.babzip.backend.user.domain.User;
 import com.babzip.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-@Service
 @RequiredArgsConstructor
+@Service
 public class GuestbookService {
+
     private final GuestbookRepository guestbookRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public void create(Long userId, GuestbookRequestDto dto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 없습니다."));
-
-        Guestbook guestbook = new Guestbook();
-        guestbook.setUser(user);
-        guestbook.setKakaoPlaceId(dto.getKakaoPlaceId());
-        guestbook.setContent(dto.getContent());
-        guestbook.setRating(dto.getRating());
-
+        User user = getUser(userId);
+        Guestbook guestbook = new Guestbook(user, dto.getKakaoPlaceId(), dto.getContent(), dto.getRating());
         guestbookRepository.save(guestbook);
     }
 
-    public List<GuestbookResponseDto> getByKakaoPlaceId(String kakaoPlaceId) {
-        return guestbookRepository.findByKakaoPlaceId(kakaoPlaceId).stream()
-                .map(this::toDto)
-                .collect(Collectors.toList());
+    @Transactional(readOnly = true)
+    public Page<GuestbookResponseDto> getByUserId(Long userId, Pageable pageable) {
+        return guestbookRepository.findByUserId(userId, pageable)
+                .map(GuestbookResponseDto::toDto);
     }
 
-    public List<GuestbookResponseDto> getByUserId(Long userId) {
-        return guestbookRepository.findByUserId(userId).stream()
-                .map(this::toDto)
-                .collect(Collectors.toList());
+    @Transactional
+    public void updateAll(Long userId, Long guestbookId, GuestbookRequestDto dto) {
+        Guestbook guestbook = getOwnedGuestbook(userId, guestbookId);
+        guestbook.updateAll(dto.getKakaoPlaceId(), dto.getContent(), dto.getRating());
     }
 
-    public void update(Long guestbookId, Long userId, GuestbookRequestDto dto) {
-        Guestbook guestbook = guestbookRepository.findByIdAndUserId(guestbookId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("수정 권한이 없습니다."));
-
-        guestbook.setContent(dto.getContent());
-        guestbook.setRating(dto.getRating());
+    @Transactional
+    public void updatePartial(Long userId, Long guestbookId, GuestbookRequestDto dto) {
+        Guestbook guestbook = getOwnedGuestbook(userId, guestbookId);
+        guestbook.updatePartial(dto.getContent(), dto.getRating());
     }
 
-    public void delete(Long guestbookId, Long userId) {
-        Guestbook guestbook = guestbookRepository.findByIdAndUserId(guestbookId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("삭제 권한이 없습니다."));
-
+    @Transactional
+    public void delete(Long userId, Long guestbookId) {
+        Guestbook guestbook = getOwnedGuestbook(userId, guestbookId);
         guestbookRepository.delete(guestbook);
     }
 
-    private GuestbookResponseDto toDto(Guestbook g) {
-        return new GuestbookResponseDto(
-                g.getGuestbookId(),
-                g.getKakaoPlaceId(),
-                g.getContent(),
-                g.getRating()
-        );
+    private Guestbook getOwnedGuestbook(Long userId, Long guestbookId) {
+        return guestbookRepository.findByIdAndUserId(guestbookId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 방명록을 찾을 수 없습니다."));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
@@ -1,0 +1,69 @@
+package com.babzip.backend.guestbook.service;
+
+import com.babzip.backend.guestbook.dto.request.GuestbookRequestDto;
+import com.babzip.backend.guestbook.dto.response.GuestbookResponseDto;
+import com.babzip.backend.guestbook.entity.Guestbook;
+import com.babzip.backend.guestbook.repository.GuestbookRepository;
+import com.babzip.backend.user.domain.User;
+import com.babzip.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GuestbookService {
+    private final GuestbookRepository guestbookRepository;
+    private final UserRepository userRepository;
+
+    public void create(Long userId, GuestbookRequestDto dto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보가 없습니다."));
+
+        Guestbook guestbook = new Guestbook();
+        guestbook.setUser(user);
+        guestbook.setKakaoPlaceId(dto.getKakaoPlaceId());
+        guestbook.setContent(dto.getContent());
+        guestbook.setRating(dto.getRating());
+
+        guestbookRepository.save(guestbook);
+    }
+
+    public List<GuestbookResponseDto> getByKakaoPlaceId(String kakaoPlaceId) {
+        return guestbookRepository.findByKakaoPlaceId(kakaoPlaceId).stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public List<GuestbookResponseDto> getByUserId(Long userId) {
+        return guestbookRepository.findByUserId(userId).stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public void update(Long guestbookId, Long userId, GuestbookRequestDto dto) {
+        Guestbook guestbook = guestbookRepository.findByIdAndUserId(guestbookId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("수정 권한이 없습니다."));
+
+        guestbook.setContent(dto.getContent());
+        guestbook.setRating(dto.getRating());
+    }
+
+    public void delete(Long guestbookId, Long userId) {
+        Guestbook guestbook = guestbookRepository.findByIdAndUserId(guestbookId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("삭제 권한이 없습니다."));
+
+        guestbookRepository.delete(guestbook);
+    }
+
+    private GuestbookResponseDto toDto(Guestbook g) {
+        return new GuestbookResponseDto(
+                g.getGuestbookId(),
+                g.getKakaoPlaceId(),
+                g.getContent(),
+                g.getRating()
+        );
+    }
+}

--- a/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/babzip/backend/guestbook/service/GuestbookService.java
@@ -34,15 +34,9 @@ public class GuestbookService {
     }
 
     @Transactional
-    public void updateAll(Long userId, Long guestbookId, GuestbookRequestDto dto) {
-        Guestbook guestbook = getOwnedGuestbook(userId, guestbookId);
-        guestbook.updateAll(dto.getKakaoPlaceId(), dto.getContent(), dto.getRating());
-    }
-
-    @Transactional
     public void updatePartial(Long userId, Long guestbookId, GuestbookRequestDto dto) {
         Guestbook guestbook = getOwnedGuestbook(userId, guestbookId);
-        guestbook.updatePartial(dto.getContent(), dto.getRating());
+        guestbook.updatePartial(dto.getKakaoPlaceId(), dto.getContent(), dto.getRating());
     }
 
     @Transactional


### PR DESCRIPTION
## What is this PR?🔍

>> 사용자가 방문한 음식점에 한 줄 방명록(리뷰)을 남기고, 이를 개인적으로 관리할 수 있도록 하는 CRUD 기능을 구현했습니다.
해당 기능은 다음과 같은 목적을 가지고 있습니다:

- 내가 방문한 음식점 기록 (음식점 ID 기반)
- 내가 남긴 한 줄 방명록(리뷰)을 작성, 수정, 삭제

## Changes💻

GuestbookController에 다음 API 구현:
- POST /guestbook : 음식점 리뷰 작성
- GET /guestbook/me?userId=... : 내가 남긴 모든 방명록 조회
- PUT /guestbook/{guestbookId} : 내 리뷰 수정
- DELETE /guestbook/{guestbookId} : 내 리뷰 삭제

- 모든 Guestbook API에 @PreAuthorize("isAuthenticated()") 적용
- @AssignUserId 어노테이션 사용하여 userId 주입
- 엔티티에서 @Setter 제거 → 생성자/메서드 기반 값 수정
- DTO 변환 책임을 DTO 내부로 이동
- getMyGuestbooks 응답을 Page<GuestbookResponseDto>로 변경
- createSuccessResponse()로 응답 형식 통일

## Note ⚠️
- @AssignUserId 파라미터 적용은 아직 구현되지 않았으며 추후 PR 예정입니다.
 
## ScreenShot📷
