### PR TITLE
chore: 비어있는 필드를 Null을 채워서 반환하도록 수정

### DIFF
--- a/src/main/java/com/babzip/backend/top10/dto/response/Top10Response.java
+++ b/src/main/java/com/babzip/backend/top10/dto/response/Top10Response.java
@@ -14,4 +14,8 @@ public record Top10Response (
                 top10.getRankValue()
         );
     }
+
+    public static Top10Response empty() {
+        return new Top10Response(null, null, null);
+    }
 }

--- a/src/main/java/com/babzip/backend/top10/service/Top10Service.java
+++ b/src/main/java/com/babzip/backend/top10/service/Top10Service.java
@@ -8,11 +8,13 @@ import com.babzip.backend.top10.dto.response.Top10Response;
 import com.babzip.backend.top10.repository.Top10Repository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -48,8 +50,19 @@ public class Top10Service {
     }
 
     public Page<Top10Response> getTop10(Long userId, Pageable pageable){
-        Page<Top10> response = top10Repository.findByUserId(userId, pageable);
-        return response.map(Top10Response::toDto);
+        Page<Top10> result = top10Repository.findByUserId(userId, pageable);
 
+        List<Top10Response> content = result.getContent().stream()
+                .map(Top10Response::toDto)
+                .collect(Collectors.toList());
+
+        int requestedSize = pageable.getPageSize();
+        int missingCount = requestedSize - content.size();
+
+        for (int i = 0; i < missingCount; i++) {
+            content.add(Top10Response.empty()); // 필드값이 모두 null인 객체 추가
+        }
+
+        return new PageImpl<>(content, pageable, requestedSize);
     }
 }


### PR DESCRIPTION
## What is this PR?🔍
- top10은 조회 api 호출 시 항상 10개의 페이지를 반환하므로 조회 시 비어있는 필드는 null을 채워서 반환하도록 수정했습니다.
- 
## Changes💻
- dto에 null 값을 반환해주는 메서드를 추가했습니다.
-
-

## ScreenShot📷
