### PR TITLE
chore: rankValue는 null이 아닌 값을 채워서 반환하도록 수정

### DIFF
--- a/src/main/java/com/babzip/backend/top10/dto/response/Top10Response.java
+++ b/src/main/java/com/babzip/backend/top10/dto/response/Top10Response.java
@@ -15,7 +15,7 @@ public record Top10Response (
         );
     }
 
-    public static Top10Response empty() {
-        return new Top10Response(null, null, null);
+    public static Top10Response empty(Long currCount) {
+        return new Top10Response(null, null, currCount);
     }
 }

--- a/src/main/java/com/babzip/backend/top10/service/Top10Service.java
+++ b/src/main/java/com/babzip/backend/top10/service/Top10Service.java
@@ -57,10 +57,12 @@ public class Top10Service {
                 .collect(Collectors.toList());
 
         int requestedSize = pageable.getPageSize();
-        int missingCount = requestedSize - content.size();
 
-        for (int i = 0; i < missingCount; i++) {
-            content.add(Top10Response.empty()); // 필드값이 모두 null인 객체 추가
+        int currCount = content.size();
+
+        for (int i = currCount + 1; i <= requestedSize; i++) {
+            content.add(Top10Response.empty((long) i)); // 필드값이 모두 null인 객체 추가
+
         }
 
         return new PageImpl<>(content, pageable, requestedSize);


### PR DESCRIPTION
## What is this PR?🔍
- top10 반환 시 rankValue는 값을 채워서 반환하도록 수정합니다.
- 
## Changes💻
- 만약 8개의 값이 채워져있고 2개의 값이 null로 전달되어야 한다면, 2개의 값들의 rankVaule는 9, 10으로 채워져 보내집니다.
-
-

## ScreenShot📷
